### PR TITLE
Load pre-trained model parameters Functionality

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# .ipynb
+*.ipynb linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 # Python
 *.pyc
 
+# PyTorch
+*.pth
 # Misc
 logs_hydra/
 ml-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ logs_hydra/
 ml-runs/
 mlruns/
 lightning_logs/
+pretrained_models/*.txt
 
 # macOS
 .DS_Store

--- a/configs/model/model_vit.yaml
+++ b/configs/model/model_vit.yaml
@@ -1,4 +1,5 @@
 model_type: 'ViT-B' # 'ViT-B', 'ViT-L', 'ViT-H', 'custom'
+pretrained_path: "./pretrained_models/jx_vit_base_patch16_224_in21k-e5005f0a.pth" # "chkpt path" or None
 input_channels: 3
 image_size: 224
 num_hidden_layers: 12
@@ -7,8 +8,9 @@ patch_size: 16
 hidden_size: 768
 hidden_activation: 'gelu'
 intermediate_size: 3072
-hidden_dropout_prob: 0.0
-attention_probs_dropout_prob: 0.0
+hidden_dropout_prob: 0.1
+attention_probs_dropout_prob: 0.1
+qkv_bias: True
 num_classes: 10
 initializer_range: 0.02
 layer_norm_eps: 1e-12

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,2 +1,3 @@
+from .vit import *
 from .vit_model import *
 from .vit_module import *

--- a/models/vit.py
+++ b/models/vit.py
@@ -1,0 +1,134 @@
+"""
+Modified from:
+https://github.com/lucidrains/vit-pytorch/blob/main/vit_pytorch/vit.py
+"""
+import torch
+from torch import nn
+
+from einops import rearrange, repeat
+from einops.layers.torch import Rearrange
+
+# helpers
+
+def pair(t):
+    return t if isinstance(t, tuple) else (t, t)
+
+# classes
+
+class FeedForward(nn.Module):
+    def __init__(self, dim, hidden_dim, dropout = 0.):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.LayerNorm(dim),
+            nn.Linear(dim, hidden_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_dim, dim),
+            nn.Dropout(dropout)
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+class Attention(nn.Module):
+    def __init__(self, dim, heads = 8, dim_head = 64, dropout = 0., qkv_bias = False):
+        super().__init__()
+        inner_dim = dim_head *  heads
+        project_out = not (heads == 1 and dim_head == dim)
+
+        self.heads = heads
+        self.scale = dim_head ** -0.5
+
+        self.norm = nn.LayerNorm(dim)
+
+        self.attend = nn.Softmax(dim = -1)
+        self.dropout = nn.Dropout(dropout)
+
+        self.to_qkv = nn.Linear(dim, inner_dim * 3, bias = qkv_bias)
+
+        self.to_out = nn.Sequential(
+            nn.Linear(inner_dim, dim),
+            nn.Dropout(dropout)
+        ) if project_out else nn.Identity()
+
+    def forward(self, x):
+        x = self.norm(x)
+
+        qkv = self.to_qkv(x).chunk(3, dim = -1)
+        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> b h n d', h = self.heads), qkv)
+
+        dots = torch.matmul(q, k.transpose(-1, -2)) * self.scale
+
+        attn = self.attend(dots)
+        attn = self.dropout(attn)
+
+        out = torch.matmul(attn, v)
+        out = rearrange(out, 'b h n d -> b n (h d)')
+        return self.to_out(out)
+
+class Transformer(nn.Module):
+    def __init__(self, dim, depth, heads, dim_head, mlp_dim, dropout = 0., qkv_bias = False):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+        self.layers = nn.ModuleList([])
+        for _ in range(depth):
+            self.layers.append(nn.ModuleList([
+                Attention(dim, heads = heads, dim_head = dim_head, dropout = dropout, qkv_bias = qkv_bias),
+                FeedForward(dim, mlp_dim, dropout = dropout)
+            ]))
+
+    def forward(self, x):
+        for attn, ff in self.layers:
+            x = attn(x) + x
+            x = ff(x) + x
+
+        return self.norm(x)
+
+class ViT(nn.Module):
+    def __init__(self, *, image_size, patch_size, num_classes, dim, depth, heads, mlp_dim, pool = 'cls', channels = 3, dim_head = 64, dropout = 0., emb_dropout = 0., qkv_bias=True):
+        super().__init__()
+        image_height, image_width = pair(image_size)
+        patch_height, patch_width = pair(patch_size)
+
+        assert image_height % patch_height == 0 and image_width % patch_width == 0, 'Image dimensions must be divisible by the patch size.'
+
+        num_patches = (image_height // patch_height) * (image_width // patch_width)
+        patch_dim = channels * patch_height * patch_width
+        assert pool in {'cls', 'mean'}, 'pool type must be either cls (cls token) or mean (mean pooling)'
+
+        self.to_patch_embedding = nn.Sequential(
+            # use conv2d to fit the pre-trained weight file
+            nn.Conv2d(channels, dim, kernel_size=patch_size, stride=patch_size),
+            # Rearrange('b c (h p1) (w p2) -> b (h w) (p1 p2 c)', p1 = patch_height, p2 = patch_width),
+            # nn.LayerNorm(patch_dim),
+            # nn.Linear(patch_dim, dim),
+            # nn.LayerNorm(dim),
+        )
+
+        self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, dim))
+        self.cls_token = nn.Parameter(torch.randn(1, 1, dim))
+        self.dropout = nn.Dropout(emb_dropout)
+
+        self.transformer = Transformer(dim, depth, heads, dim_head, mlp_dim, dropout, qkv_bias)
+
+        self.pool = pool
+        self.to_latent = nn.Identity()
+
+        self.mlp_head = nn.Linear(dim, num_classes)
+
+    def forward(self, img):
+        x = self.to_patch_embedding(img) # [B, C, H, W]
+        x = x.flatten(2).transpose(1,2) # [B, N, C]
+        b, n, _ = x.shape
+
+        cls_tokens = repeat(self.cls_token, '1 1 d -> b 1 d', b = b)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x += self.pos_embedding[:, :(n + 1)]
+        x = self.dropout(x)
+
+        x = self.transformer(x)
+
+        x = x.mean(dim = 1) if self.pool == 'mean' else x[:, 0]
+
+        x = self.to_latent(x)
+        return self.mlp_head(x)

--- a/models/vit_model.py
+++ b/models/vit_model.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
-from vit_pytorch import ViT
+# from vit_pytorch import ViT
+from .vit import ViT
 from transformers import ViTConfig
 import pytorch_lightning as pl
 import torchmetrics
@@ -11,14 +12,15 @@ class VisionTransformer(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.model = ViT(image_size = config.image_size,
-                         patch_size = config.patch_size,
-                         num_classes = config.num_classes,
-                         dim = config.hidden_size,
-                         depth = config.num_hidden_layers,
-                         heads = config.num_attention_heads,
-                         mlp_dim = config.intermediate_size,
-                         dropout = config.hidden_dropout_prob,
-                         emb_dropout = config.attention_probs_dropout_prob)
+                            patch_size = config.patch_size,
+                            num_classes = config.num_classes,
+                            dim = config.hidden_size,
+                            depth = config.num_hidden_layers,
+                            heads = config.num_attention_heads,
+                            mlp_dim = config.intermediate_size,
+                            dropout = config.hidden_dropout_prob,
+                            emb_dropout = config.attention_probs_dropout_prob,
+                            qkv_bias = config.qkv_bias)
     
     @torch.no_grad()
     def init_weights(self):

--- a/pretrained_models/README.md
+++ b/pretrained_models/README.md
@@ -42,42 +42,42 @@ links to weights:
 - https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx
 
 ```
-load the jax pretrained weights from timm, note that we remove many unnecessary components (e.g., mlp_head) 
+Load the jax->PyTorch(.pth) pretrained weights from timm, note that we remove many unnecessary components (e.g., mlp_head) 
         
-weights can be downloaded from here: https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx
-        you can download various pretriained weights and adjust your codes to fit them
+Weights can be downloaded from here: https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx
+    
+you can download various pretriained weights and adjust your codes to fit them
+ideas from https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/blob/master/tools/trans_weight.py
 
-  ideas from https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/blob/master/tools/trans_weight.py
+Weights mapping is as follows:
+                    -----------Model Parameters------------
+    timm_jax_vit_base                           self
 
-        weights mapping as follows:
-                        -----------Model Parameters------------
-        timm_jax_vit_base                           self
+    pos_embed                       pos_embedding
+    patch_embed.proj.weight         to_patch_embedding.0.weights
+    patch_embed.proj.bias           to_patch_embedding.0.bias
+    cls_token                       cls_token
+    norm.weight                     model.transformer.norm.weight
+    norm.bias                       model.transformer.norm.bias
 
-        pos_embed                            pos_embedding
-        patch_embed.proj.weight              to_patch_embedding.0.weights
-        patch_embed.proj.bias                to_patch_embedding.0.bias
-        cls_token                            cls_token
-        norm.weight                          transformer.norm.weight
-        norm.bias                            transformer.norm.bias
+                    -----------Attention Layer-------------
+    blocks.0.norm1.weight       model.transformer.layers.0.0.norm.weight
+    blocks.0.norm1.bias         model.transformer.layers.0.0.norm.bias
+    blocks.0.attn.qkv.weight    model.transformer.layers.0.0.to_qkv.weight
+    blocks.0.attn.qkv.bias      model.transformer.layers.0.0.to_qkv.bias
+    blocks.0.attn.proj.weight   model.transformer.layers.0.0.to_out.0.weight
+    blocks.0.attn.proj.bias     model.transformer.layers.0.0.to_out.0.bias
 
-                        -----------Attention Layer-------------
-        blocks.0.norm1.weight            transformer.layers.0.0.norm.weight
-        blocks.0.norm1.bias              transformer.layers.0.0.norm.bias
-        blocks.0.attn.qkv.weight         transformer.layers.0.0.to_qkv.weight
-        blocks.0.attn.qkv.bias           transformer.layers.0.0.to_qkv.bias
-        blocks.0.attn.proj.weight        transformer.layers.0.0.to_out.0.weight
-        blocks.0.attn.proj.bias          transformer.layers.0.0.to_out.0.bias
-        
-                        -----------MLP Layer-------------
-        blocks.0.norm2.weight            transformer.layers.0.1.net.0.weight
-        blocks.0.norm2.bias              transformer.layers.0.1.net.0.bias
-        blocks.0.mlp.fc1.weight          transformer.layers.0.1.net.1.weight
-        blocks.0.mlp.fc1.bias            transformer.layers.0.1.net.1.bias
-        blocks.0.mlp.fc2.weight          transformer.layers.0.1.net.4.weight
-        blocks.0.mlp.fc2.bias            transformer.layers.0.1.net.4.bias
-                .                                          .
-                .                                          .
-                .                                          .
+                    -----------MLP Layer-------------
+    blocks.0.norm2.weight       model.transformer.layers.0.1.net.0.weight
+    blocks.0.norm2.bias         model.transformer.layers.0.1.net.0.bias
+    blocks.0.mlp.fc1.weight     model.transformer.layers.0.1.net.1.weight
+    blocks.0.mlp.fc1.bias       model.transformer.layers.0.1.net.1.bias
+    blocks.0.mlp.fc2.weight     model.transformer.layers.0.1.net.4.weight
+    blocks.0.mlp.fc2.bias       model.transformer.layers.0.1.net.4.bias
+            .                                          .
+            .                                          .
+            .                                          .
         """
 ```
 

--- a/pretrained_models/README.md
+++ b/pretrained_models/README.md
@@ -41,11 +41,12 @@ To this end, we recommend coping the script `vit.py` in the local project. The m
 
 Add functionality to load pre-trained weights (ImageNet) to `vit_module.py`:
 
-Code to load weights:
+Useful links and code to load weights:
 - https://github.com/lucidrains/vit-pytorch/issues/239
 - https://github.com/liyiersan/MSA/blob/22243186133369941bb78bbd93e6e2cd04317f66/models/vit.py#L133-L211
 - https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/tree/master/tools
 - https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/blob/master/utils/utils.py#L44
+
 links to weights:
 - https://github.com/huggingface/pytorch-image-models/releases?page=7
 - https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx

--- a/pretrained_models/README.md
+++ b/pretrained_models/README.md
@@ -1,0 +1,83 @@
+# Load Pre-Trained ViT models:
+
+ViT DNNs do not train well on small datasets (e.g., CIFAR-10). Therefore, it is recommended to use a pre-trained model.
+<!-- ## Adding Functionality to Load Pre-trained Models -->
+If we use the `vit-pytorch` library additional modifications are needed to properly load the weights of the original pre-trained models, e.g., (ViT-B/16). These modifications are described below.
+
+
+## Modifications in the `vit.py` script
+To properly load the parameters of a ViT pre-trained model into a `vit-pytorch` ViT DNN, we need to perform two modifications in the `vit.py`.
+To this end, we recommend coping the script `vit.py` in the local project. The modifications are the following:
+
+1. Add `qkv_bias` parameter in the Attention class.
+2. In the `ViT` class use `nn.Conv2d` for the `to_patch_embedding` layer:
+
+    ```python
+    self.to_patch_embedding = nn.Sequential(
+            # use conv2d to fit the pre-trained weight file
+            nn.Conv2d(channels, dim, kernel_size=patch_size, stride=patch_size)
+        )
+    ```
+    instead of
+    ```python
+    self.to_patch_embedding = nn.Sequential(
+            Rearrange('b c (h p1) (w p2) -> b (h w) (p1 p2 c)', p1 = patch_height, p2 = patch_width),
+            nn.LayerNorm(patch_dim),
+            nn.Linear(patch_dim, dim),
+            nn.LayerNorm(dim),
+        )
+    ```
+
+## Adding functionality in the `vit_module.py`
+
+Add functionality to load pre-trained weights (ImageNet) to `vit_module.py`:
+
+Code to load weights:
+- https://github.com/lucidrains/vit-pytorch/issues/239
+- https://github.com/liyiersan/MSA/blob/22243186133369941bb78bbd93e6e2cd04317f66/models/vit.py#L133-L211
+- https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/tree/master/tools
+- https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/blob/master/utils/utils.py#L44
+links to weights:
+- https://github.com/huggingface/pytorch-image-models/releases?page=7
+- https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx
+
+```
+load the jax pretrained weights from timm, note that we remove many unnecessary components (e.g., mlp_head) 
+        
+weights can be downloaded from here: https://github.com/huggingface/pytorch-image-models/releases/tag/v0.1-vitjx
+        you can download various pretriained weights and adjust your codes to fit them
+
+  ideas from https://github.com/Sebastian-X/vit-pytorch-with-pretrained-weights/blob/master/tools/trans_weight.py
+
+        weights mapping as follows:
+                        -----------Model Parameters------------
+        timm_jax_vit_base                           self
+
+        pos_embed                            pos_embedding
+        patch_embed.proj.weight              to_patch_embedding.0.weights
+        patch_embed.proj.bias                to_patch_embedding.0.bias
+        cls_token                            cls_token
+        norm.weight                          transformer.norm.weight
+        norm.bias                            transformer.norm.bias
+
+                        -----------Attention Layer-------------
+        blocks.0.norm1.weight            transformer.layers.0.0.norm.weight
+        blocks.0.norm1.bias              transformer.layers.0.0.norm.bias
+        blocks.0.attn.qkv.weight         transformer.layers.0.0.to_qkv.weight
+        blocks.0.attn.qkv.bias           transformer.layers.0.0.to_qkv.bias
+        blocks.0.attn.proj.weight        transformer.layers.0.0.to_out.0.weight
+        blocks.0.attn.proj.bias          transformer.layers.0.0.to_out.0.bias
+        
+                        -----------MLP Layer-------------
+        blocks.0.norm2.weight            transformer.layers.0.1.net.0.weight
+        blocks.0.norm2.bias              transformer.layers.0.1.net.0.bias
+        blocks.0.mlp.fc1.weight          transformer.layers.0.1.net.1.weight
+        blocks.0.mlp.fc1.bias            transformer.layers.0.1.net.1.bias
+        blocks.0.mlp.fc2.weight          transformer.layers.0.1.net.4.weight
+        blocks.0.mlp.fc2.bias            transformer.layers.0.1.net.4.bias
+                .                                          .
+                .                                          .
+                .                                          .
+        """
+```
+

--- a/pretrained_models/README.md
+++ b/pretrained_models/README.md
@@ -9,7 +9,7 @@ If we use the `vit-pytorch` library additional modifications are needed to prope
 To properly load the parameters of a ViT pre-trained model into a `vit-pytorch` ViT DNN, we need to perform two modifications in the `vit.py`.
 To this end, we recommend coping the script `vit.py` in the local project. The modifications are the following:
 
-1. Add `qkv_bias` parameter in the Attention class.
+1. Add the `qkv_bias` parameter in the Attention class and enable the use of the parameters through the `ViT` class.
 2. In the `ViT` class use `nn.Conv2d` for the `to_patch_embedding` layer:
 
     ```python
@@ -18,7 +18,8 @@ To this end, we recommend coping the script `vit.py` in the local project. The m
             nn.Conv2d(channels, dim, kernel_size=patch_size, stride=patch_size)
         )
     ```
-    instead of
+    instead of:
+
     ```python
     self.to_patch_embedding = nn.Sequential(
             Rearrange('b c (h p1) (w p2) -> b (h w) (p1 p2 c)', p1 = patch_height, p2 = patch_width),
@@ -27,6 +28,14 @@ To this end, we recommend coping the script `vit.py` in the local project. The m
             nn.LayerNorm(dim),
         )
     ```
+
+    Then, modify the `forward(self, img)` method to match with the `self.to_patch_embedding` layer modifications.
+    ```python
+    x = self.to_patch_embedding(img) # [B, C, H, W]
+        x = x.flatten(2).transpose(1,2) # [B, N, C]
+        b, n, _ = x.shape
+    ```
+
 
 ## Adding functionality in the `vit_module.py`
 


### PR DESCRIPTION
To properly load the parameters of a ViT pre-trained model into a `vit-pytorch` ViT DNN, we need to perform two modifications in the `vit.py`.
To this end, we recommend copying the script `vit.py` in the local project. The modifications are the following:

1. Add the `qkv_bias` parameter in the Attention class and enable the use of the parameters through the `ViT` class.
2. In the `ViT` class use `nn.Conv2d` for the `to_patch_embedding` layer:

    ```python
    self.to_patch_embedding = nn.Sequential(
            # use conv2d to fit the pre-trained weight file
            nn.Conv2d(channels, dim, kernel_size=patch_size, stride=patch_size)
        )
    ```
    instead of:

    ```python
    self.to_patch_embedding = nn.Sequential(
            Rearrange('b c (h p1) (w p2) -> b (h w) (p1 p2 c)', p1 = patch_height, p2 = patch_width),
            nn.LayerNorm(patch_dim),
            nn.Linear(patch_dim, dim),
            nn.LayerNorm(dim),
        )
    ```

    Then, modify the `forward(self, img)` method to match with the `self.to_patch_embedding` layer modifications.
    ```python
    x = self.to_patch_embedding(img) # [B, C, H, W]
        x = x.flatten(2).transpose(1,2) # [B, N, C]
        b, n, _ = x.shape
    ```